### PR TITLE
Simplify IOUtil string manipulation and modify MRule property accessors

### DIFF
--- a/CmlLib/Core/MRule.cs
+++ b/CmlLib/Core/MRule.cs
@@ -20,8 +20,8 @@ public static class MRule
             Arch = "32";
     }
 
-    public static string OSName { get; internal set; }
-    public static string Arch { get; internal set; }
+    public static string OSName { get; set; }
+    public static string Arch { get; set; }
 
     public static string getOSName()
     {

--- a/CmlLib/Utils/IOUtil.cs
+++ b/CmlLib/Utils/IOUtil.cs
@@ -43,12 +43,7 @@ internal static class IOUtil
         return string.Join(";",
             paths.Select(x =>
             {
-                var path = Path.GetFullPath(x);
-                return "\"" + path + "\"";
-                if (path.Contains(' '))
-                    return "\"" + path + "\"";
-                else
-                    return path;
+                return Path.GetFullPath(x);;
             }));
     }
 


### PR DESCRIPTION
The IOUtil class has been streamlined to eliminate unnecessary path manipulation, resulting in cleaner code. At the same time, the accessors for the OSName and Arch properties in the MRule class have been changed from internal set to regular set, to improve class usability and flexibility.