### PR TITLE
Refactor path validation and remove extra semicolon

### DIFF
--- a/CmlLib/Utils/IOUtil.cs
+++ b/CmlLib/Utils/IOUtil.cs
@@ -43,7 +43,7 @@ internal static class IOUtil
         return string.Join(";",
             paths.Select(x =>
             {
-                return Path.GetFullPath(x);;
+                return Path.GetFullPath(x);
             }));
     }
 


### PR DESCRIPTION
This commit refactors the way paths are validated in the MLaunch class and removes an unnecessary semicolon from the IOUtil class. This provides a more reliable method for ensuring the correct format of paths based on the operating system, improving the robustness of the application.